### PR TITLE
Update readme to follow ros2 changes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 mkdir -p ~/hebi_ws/src
 cd ~/hebi_ws/src
 git clone -b ros2 https://github.com/HebiRobotics/hebi_cpp_api_ros
-git clone https://github.com/HebiRobotics/hebi_description.git
+git clone -b ros2 https://github.com/HebiRobotics/hebi_description
 git clone https://github.com/HebiRobotics/hebi_ros2_cpp_examples
 git clone https://github.com/HebiRobotics/hebi_msgs
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ cd ~/hebi_ws/src
 git clone -b ros2 https://github.com/HebiRobotics/hebi_cpp_api_ros
 git clone https://github.com/HebiRobotics/hebi_description.git
 git clone https://github.com/HebiRobotics/hebi_ros2_cpp_examples
+git clone https://github.com/HebiRobotics/hebi_msgs
 ```
 
 Optional: If you want HEBI packages for `ros2_control`, execute these too.


### PR DESCRIPTION
1. in hebi_description, ros2 is not yet the default repo so I have to add before cloning
2. hebi_msgs package was missing, so I added this repository to clone